### PR TITLE
Make base image configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # FROM alpine:latest
 # RUN apk --update upgrade && apk add bash nfs-utils && rm -rf /var/cache/apk/*
 
-FROM debian:stable
+ARG BUILD_FROM=debian:stretch-slim
+
+FROM $BUILD_FROM
 
 # kmod is required for lsmod
 # libcap2-bin is required for checking capabilities

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ARG BUILD_FROM=debian:stretch-slim
 
 FROM $BUILD_FROM
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 # kmod is required for lsmod
 # libcap2-bin is required for checking capabilities
 RUN apt-get update                                                                && \


### PR DESCRIPTION
this PR allows the base image to be set with a `BUILD_FROM` env var

it also defaults to the more lightweight stretch-slim, and makes package install non-interactive