### PR TITLE
Fixed the kernel module assertion to consider builtin modules

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -226,7 +226,7 @@ assert_kernel_mod() {
 
   log "checking for presence of kernel module: $moduleName"
 
-  lsmod | grep -Eq "^$moduleName\\s+"
+  lsmod | grep -Eq "^$moduleName\\s+" || [ -d "/sys/module/$moduleName" ]
 
   exit_on_failure "$moduleName module is not loaded on the Docker host's kernel (try: modprobe $moduleName)"
 }


### PR DESCRIPTION
This PR addresses the issue when the nfs and nfsd modules are built into kernel. the docker-machine/minikube VM images have them builtin.
`lsmod` lists only dynamically loaded ones.
`cat /lib/modules/$(uname -r)/modules.builtin` consists of a list of builtin modules, but it is not accessible from a container. instead, `/sys/module/*` directories are used as indicators of presence of certain builtin modules.