### PR TITLE
Dockerfile: use alpine:3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=alpine:latest
+ARG BUILD_FROM=alpine:3.9
 
 FROM $BUILD_FROM
 


### PR DESCRIPTION
Alpine 3.9 privides the nfs-utils 2.3.2-r1. I have tested
the basic functionality and it works just fine for me.
Fixes the https://github.com/ehough/docker-nfs-server/issues/15

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>