### PR TITLE
Set grace period to 10 seconds for nfsv4

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -711,7 +711,7 @@ boot_main_nfsd() {
   read -r -a version_flags <<< "$(boot_helper_get_version_flags)"
   local -r threads="${state[$STATE_NFSD_THREAD_COUNT]}"
   local -r port="${state[$STATE_NFSD_PORT]}"
-  local args=('--tcp' '--udp' '--port' "$port" "${version_flags[@]}" "$threads")
+  local args=('--tcp' '--udp' '-G' '10' '--port' "$port" "${version_flags[@]}" "$threads")
 
   if is_logging_debug; then
     args+=('--debug')


### PR DESCRIPTION
Set the default `grace-period` to 10 seconds.

Fixes #22 

Not sure if this should be configurable or where best to put the flag.

In my limited testing this speeds up initial file access on an `nfsv4` mount from `~100s` to `<1s`

Not sure why the grace period is set so long by default

Im also unclear as to why setting `10` for the grace period cuts the time to under a second - the man page seems to suggest that the grace-period is measured in seconds:

https://manpages.debian.org/stretch/nfs-kernel-server/nfsd.8.en.html