### PR TITLE
Add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN mkdir -p /var/lib/nfs/rpc_pipefs                                            
 
 EXPOSE 2049
 
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+	CMD exportfs || exit 1
+
 # setup entrypoint
 COPY ./entrypoint.sh /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
I think `exportfs` provides a fairly reliable way to check whether the container is healthy, so it seems to me make sense to add the healthcheck in the image - ie the healthcheck doesnt require any runtime vars