### PR TITLE
Latest alpine changes output of capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,11 @@ ARG BUILD_FROM=alpine:latest
 FROM $BUILD_FROM
 
 RUN apk --update --no-cache add bash nfs-utils tzdata && \
-                                                         \
     # remove the default config files
-    rm -v /etc/idmapd.conf /etc/exports
-
-# http://wiki.linux-nfs.org/wiki/index.php/Nfsv4_configuration
-RUN mkdir -p /var/lib/nfs/rpc_pipefs                                                     && \
-    mkdir -p /var/lib/nfs/v4recovery                                                     && \
+    rm -v /etc/idmapd.conf /etc/exports && \
+    # http://wiki.linux-nfs.org/wiki/index.php/Nfsv4_configuration
+    mkdir -p /var/lib/nfs/rpc_pipefs /var/lib/nfs/v4recovery && \
+    mkdir /export && chmod a+rwxt /export && \
     echo "rpc_pipefs  /var/lib/nfs/rpc_pipefs  rpc_pipefs  defaults  0  0" >> /etc/fstab && \
     echo "nfsd        /proc/fs/nfsd            nfsd        defaults  0  0" >> /etc/fstab
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG BUILD_FROM=alpine:latest
 
 FROM $BUILD_FROM
 
-RUN apk --update --no-cache add bash nfs-utils && \
-                                                  \
+RUN apk --update --no-cache add bash nfs-utils tzdata && \
+                                                         \
     # remove the default config files
     rm -v /etc/idmapd.conf /etc/exports
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG BUILD_FROM=alpine:latest
 FROM $BUILD_FROM
 
 RUN apk --update --no-cache add bash nfs-utils && \
+                                                  \
     # remove the default config files
     rm -v /etc/idmapd.conf /etc/exports
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG BUILD_FROM=alpine:latest
 FROM $BUILD_FROM
 
 RUN apk --update --no-cache add bash nfs-utils && \
-                                                  \
     # remove the default config files
     rm -v /etc/idmapd.conf /etc/exports
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -442,6 +442,7 @@ init_exports() {
 
     log "building $PATH_FILE_ETC_EXPORTS from environment variables"
 
+    mkdir -p /share && chmod a+rwxt /share
     exports='/share *(ro,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash,fsid=root)'
     exports=$exports$'\n'
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -272,6 +272,7 @@ is_kernel_module_loaded() {
 }
 
 is_granted_linux_capability() {
+
   if capsh --print | grep -Eq "^Current:.*,?${1}(,|$)"; then
     return 0
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -272,8 +272,7 @@ is_kernel_module_loaded() {
 }
 
 is_granted_linux_capability() {
-
-  if capsh --print | grep -Eq "^Current: = .*,?${1}(,|$)"; then
+  if capsh --print | grep -Eq "^Current:.*,?${1}(,|$)"; then
     return 0
   fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -273,7 +273,7 @@ is_kernel_module_loaded() {
 
 is_granted_linux_capability() {
 
-  if capsh --has-p=${1}; then
+  if capsh --has-p=${1} || capsh --has-p=cap_${1}; then
     return 0
   fi
   

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -273,13 +273,12 @@ is_kernel_module_loaded() {
 
 is_granted_linux_capability() {
 
-  if capsh --print | grep -Eq "^Current:.*,?${1}(,|$)"; then
+  if capsh --has-p=${1}; then
     return 0
   fi
-
+  
   return 1
 }
-
 
 ######################################################################################
 ### runtime configuration assertions
@@ -443,6 +442,9 @@ init_exports() {
 
     log "building $PATH_FILE_ETC_EXPORTS from environment variables"
 
+    exports='/share *(ro,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash,fsid=root)'
+    exports=$exports$'\n'
+
     for candidate_export_var in $candidate_export_vars; do
 
       local line="${!candidate_export_var}"
@@ -591,6 +593,10 @@ boot_main_exportfs() {
   if is_logging_debug; then
     args+=('-v')
   fi
+
+  echo 'Generated /etc/exports:'
+  cat /etc/exports
+  echo ''
 
   boot_helper_start_daemon 'starting exportfs' $PATH_BIN_EXPORTFS "${args[@]}"
 }


### PR DESCRIPTION
The latest alpine base doesn't have equal sign when printing capabilities. e.g.

```
Current: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_module,cap_sys_chroot,cap_sys_admin,cap_mknod,cap_audit_write,cap_setfcap=eip
Bounding set =cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_module,cap_sys_chroot,cap_sys_admin,cap_mknod,cap_audit_write,cap_setfcap
Ambient set =
Current IAB: cap_chown,cap_dac_override,!cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,!cap_linux_immutable,cap_net_bind_service,!cap_net_broadcast,!cap_net_admin,cap_net_raw,!cap_ipc_lock,!cap_ipc_owner,cap_sys_module,!cap_sys_rawio,cap_sys_chroot,!cap_sys_ptrace,!cap_sys_pacct,cap_sys_admin,!cap_sys_boot,!cap_sys_nice,!cap_sys_resource,!cap_sys_time,!cap_sys_tty_config,cap_mknod,!cap_lease,cap_audit_write,!cap_audit_control,cap_setfcap,!cap_mac_override,!cap_mac_admin,!cap_syslog,!cap_wake_alarm,!cap_block_suspend,!cap_audit_read
Securebits: 00/0x0/1'b0
 secure-noroot: no (unlocked)
 secure-no-suid-fixup: no (unlocked)
 secure-keep-caps: no (unlocked)
 secure-no-ambient-raise: no (unlocked)
uid=0(root) euid=0(root)
gid=0(root)
groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
Guessed mode: UNCERTAIN (
```