### PR TITLE
Fix error in new versions 'missing CAP_SYS_ADMIN' even if cap exists or is privileged

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -273,7 +273,7 @@ is_kernel_module_loaded() {
 
 is_granted_linux_capability() {
 
-  if capsh --print | grep -Eq "^Current: = .*,?${1}(,|$)"; then
+  if capsh --print | grep -Eq "^Current: ?=? .*,?${1}(,|$)"; then
     return 0
   fi
 


### PR DESCRIPTION
I've encountered this issue while building the image on my RaspberyPi.   

In the latest version `=` is removed from the `capsh` output, therefore `SYS_ADMIN` / `privileged` is not properly detected.  
This PR makes `=` optional so it retains backward compatibility and still works with most recent releases.

Fixes issue #66