### PR TITLE
feat: add ARM64 support and multi-arch build for Raspberry Pi and other ARM devices

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -1,0 +1,157 @@
+name: Docker Multi-Arch Build
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  meta:
+    name: Compute build metadata
+    runs-on: ubuntu-latest
+    outputs:
+      do_push: ${{ steps.set.outputs.do_push }}
+      is_tag: ${{ steps.set.outputs.is_tag }}
+      version: ${{ steps.set.outputs.version }}
+    steps:
+      - name: Determine push and tag info
+        id: set
+        shell: bash
+        run: |
+          echo "event=${GITHUB_EVENT_NAME}"
+          do_push=false
+          is_tag=false
+          version=
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/* ]]; then
+            is_tag=true
+            do_push=true
+            version="${GITHUB_REF_NAME}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            do_push=true
+          fi
+          if [[ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]]; then do_push=false; fi
+          echo "do_push=${do_push}" >> "$GITHUB_OUTPUT"
+          echo "is_tag=${is_tag}" >> "$GITHUB_OUTPUT"
+          if [[ -n "${version}" ]]; then
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: meta
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch_suffix: amd64
+          - platform: linux/arm64
+            arch_suffix: arm64
+    env:
+      DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/nfs-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: needs.meta.outputs.do_push == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build image (no push) ${{ matrix.platform }}
+        if: needs.meta.outputs.do_push != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: false
+          provenance: false
+          sbom: false
+
+      - name: Build and push image by digest ${{ matrix.platform }}
+        if: needs.meta.outputs.do_push == 'true'
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          sbom: false
+          outputs: type=image,name=${{ env.DOCKERHUB_REPO }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: write digest file
+        if: needs.meta.outputs.do_push == 'true'
+        shell: bash
+        run: echo "${{ steps.build.outputs.digest }}" > "digest-${{ matrix.arch_suffix }}"
+
+      - name: upload digest artifact
+        if: needs.meta.outputs.do_push == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch_suffix }}
+          path: digest-${{ matrix.arch_suffix }}
+
+  manifest:
+    name: Publish multi-arch manifests
+    needs: [meta, build]
+    if: needs.meta.outputs.do_push == 'true'
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/nfs-server
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          path: ./digests
+          merge-multiple: true
+
+      - name: Create and push 'latest' multi-arch manifest
+        shell: bash
+        run: |
+          repo="${{ env.DOCKERHUB_REPO }}"
+          amd64=$(cat ./digests/digest-amd64)
+          arm64=$(cat ./digests/digest-arm64)
+          docker buildx imagetools create \
+            -t "${repo}:latest" \
+            "${repo}@${amd64}" \
+            "${repo}@${arm64}"
+
+      - name: Create and push versioned multi-arch manifest
+        if: needs.meta.outputs.is_tag == 'true'
+        shell: bash
+        run: |
+          repo="${{ env.DOCKERHUB_REPO }}"
+          version="${{ needs.meta.outputs.version }}"
+          amd64=$(cat ./digests/digest-amd64)
+          arm64=$(cat ./digests/digest-arm64)
+          docker buildx imagetools create \
+            -t "${repo}:${version}" \
+            "${repo}@${amd64}" \
+            "${repo}@${arm64}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG BUILD_FROM=alpine:latest
 FROM $BUILD_FROM
 
 RUN apk --update --no-cache add bash nfs-utils libcap libcap-utils && \
-                                                  \
     # remove the default config files
     rm -v /etc/idmapd.conf /etc/exports
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=alpine:latest
 
 FROM $BUILD_FROM
 
-RUN apk --update --no-cache add bash nfs-utils && \
+RUN apk --update --no-cache add bash nfs-utils libcap libcap-utils && \
                                                   \
     # remove the default config files
     rm -v /etc/idmapd.conf /etc/exports

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -272,18 +272,18 @@ is_kernel_module_loaded() {
 }
 
 is_granted_linux_capability() {
-  # Original check (Debian/Ubuntu capsh format: "Current: = ...")
+  # original check (Debian-style “Current: = …cap”)
   if capsh --print | grep -Eq "^Current: = .*,?${1}(,|$)"; then
     return 0
   fi
 
-  # Fallback check (Alpine capsh format: "Current: ...")
+  # else-if: handle Alpine-style header by checking Bounding set
+  cap="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
   if capsh --print 2>/dev/null \
-    | sed -n -e 's/^Current:[[:space:]]*=[[:space:]]*//p' -e 's/^Current:[[:space:]]*//p' \
+    | sed -n 's/^Bounding set =//p' \
     | tr ',' '\n' \
-    | sed 's/[+=].*$//' \
     | sed 's/^ *//;s/ *$//' \
-    | grep -Fxq "${1}"; then
+    | grep -Fxq "$cap"; then
     return 0
   fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -148,7 +148,7 @@ term_process() {
 
   if [[ -n $pid ]]; then
     log "terminating $base"
-    kill "$pid"
+    kill $pid
     on_failure warn "unable to terminate $base"
   else
     log "$base was not running"
@@ -536,10 +536,20 @@ boot_helper_mount() {
   on_failure stop "unable to mount $type filesystem onto $path"
 }
 
+kernel_exposes_nfsd_version() {
+
+  local -r v=$1
+  grep -Eq "(^|[[:space:]])[+-]?${v}([[:space:]]|$)" "$MOUNT_PATH_NFSD/versions"
+}
+
 boot_helper_get_version_flags() {
 
   local -r requested_version="${state[$STATE_NFS_VERSION]}"
-  local flags=('--nfs-version' "$requested_version" '--no-nfs-version' 2)
+  local flags=('--nfs-version' "$requested_version")
+
+  if kernel_exposes_nfsd_version 2; then
+    flags+=('--no-nfs-version' 2)
+  fi
 
   if ! is_nfs3_enabled; then
     flags+=('--no-nfs-version' 3)
@@ -636,7 +646,7 @@ boot_main_rpcbind() {
 
   local args=('-s')
   if is_logging_debug; then
-    arg+=('-d')
+    args+=('-d')
   fi
   boot_helper_start_daemon 'starting rpcbind' $PATH_BIN_RPCBIND "${args[@]}"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -272,14 +272,23 @@ is_kernel_module_loaded() {
 }
 
 is_granted_linux_capability() {
-
+  # Original check (Debian/Ubuntu capsh format: "Current: = ...")
   if capsh --print | grep -Eq "^Current: = .*,?${1}(,|$)"; then
+    return 0
+  fi
+
+  # Fallback check (Alpine capsh format: "Current: ...")
+  if capsh --print 2>/dev/null \
+    | sed -n -e 's/^Current:[[:space:]]*=[[:space:]]*//p' -e 's/^Current:[[:space:]]*//p' \
+    | tr ',' '\n' \
+    | sed 's/[+=].*$//' \
+    | sed 's/^ *//;s/ *$//' \
+    | grep -Fxq "${1}"; then
     return 0
   fi
 
   return 1
 }
-
 
 ######################################################################################
 ### runtime configuration assertions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -542,12 +542,18 @@ kernel_exposes_nfsd_version() {
   grep -Eq "(^|[[:space:]])[+-]?${v}([[:space:]]|$)" "$MOUNT_PATH_NFSD/versions"
 }
 
+userspace_exposes_nfsd_version() {
+
+  local -r v=$1
+  rpc.nfsd --help 2>&1 | grep -Eq "[[:space:]]$v([[:space:]]|$)"
+}
+
 boot_helper_get_version_flags() {
 
   local -r requested_version="${state[$STATE_NFS_VERSION]}"
   local flags=('--nfs-version' "$requested_version")
 
-  if kernel_exposes_nfsd_version 2; then
+  if kernel_exposes_nfsd_version 2 && userspace_exposes_nfsd_version 2; then
     flags+=('--no-nfs-version' 2)
   fi
 
@@ -570,6 +576,7 @@ boot_helper_start_daemon() {
   local -r daemon_args=("$@")
 
   log "$msg"
+  log "$daemon ${daemon_args[*]}"
   "$daemon" "${daemon_args[@]}"
   on_failure stop "$daemon failed"
 }


### PR DESCRIPTION
Hi,

I'm aware this repo has been inactive for a while, but I've been using it regularly and recently tried to run it on my Raspberry Pi cluster — that’s when I found Issue #34.  
This PR implements the changes needed to make that possible.

**Summary of changes**
- Adds GitHub workflow for multi-arch builds (amd64 + arm64)
- Completes Alpine base compatibility
- Minor entrypoint adjustments to support Alpine and ARM environments
- Adds automatic disabling of NFSv2 when the kernel only exposes v3/v4

The resulting image is available at:  
👉 https://hub.docker.com/r/andrewkidd/nfs-server/tags (`v2.2.5`)

**Evidence running on Raspberry Pi 5 (ARM64 / Ubuntu 24.04 / k3s)**
```bash
# Image name
root@valar-50:/home/ubuntu# kubectl get pod nfs-5f47bb585b-7r6vf -n ainur-netboot \
  -o jsonpath='{.spec.containers[0].image}'
andrewkidd/nfs-server:v2.2.5
# Pod info
root@valar-50:/home/ubuntu# kubectl exec -it -n ainur-netboot nfs-5f47bb585b-7r6vf -- /bin/sh
Defaulted container "nfs" out of: nfs, load-nfsd (init)
/ # uname -a
Linux nfs-5f47bb585b-7r6vf 6.8.0-1031-raspi #35-Ubuntu SMP PREEMPT_DYNAMIC Thu Jul  3 15:00:20 UTC 2025 aarch64 Linux
/ # cat /etc/os-release | grep PRETTY_NAME
PRETTY_NAME="Alpine Linux v3.22"
/ # exportfs -v
/mnt/nfsshare   <world>(async,wdelay,hide,no_subtree_check,insecure_locks,fsid=0,sec=sys,rw,insecure,no_root_squash,no_all_squash)
/ #
```

manifests
```bash
$ docker manifest inspect andrewkidd/nfs-server:v2.2.5 
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1091,
         "digest": "sha256:63e143eba7c00ced4d58990b23d5152f1ae05e7e8f7ccfbe5155fb0e9035bbb8",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1091,
         "digest": "sha256:30ced108af00e6dbba208390147b3c5dc5de9c49e1ffeddad0d6be8ccb8f1ec8",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
